### PR TITLE
fixed typo in pull_request

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -1,6 +1,6 @@
 name: building-offline
 on:
-  pull-request:
+  pull_request:
     types:
       - closed
     branches:


### PR DESCRIPTION
There was a typo in the script ("pull-request" instead of "pull_request", causing the workflow to fail. It should work now.