### PR TITLE
pylsl hook error fix

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -1,5 +1,6 @@
 name: building-offline
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - closed
@@ -10,10 +11,10 @@ env:
   exploredesktop_path: 'installer\ExploreDesktopInstaller\ExploreDesktop\packages\com.Mentalab.ExploreDesktop\'
   config_path: 'installer\ExploreDesktopInstaller\ExploreDesktop\config\config.xml'
   package_path: 'installer\ExploreDesktopInstaller\ExploreDesktop\packages'
-  usedevelop: false
+  usedevelop: true
 jobs:
   build:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         os: [ windows-latest ]
@@ -47,12 +48,13 @@ jobs:
       - name: Install explorepy depencies and necessary packages
         run: |
           pip install pyinstaller==4.7
+          pip install --upgrade pyinstaller-hooks-contrib==2023.2
           pip install eeglabio
           pip install mne
           pip install -e .
           pip install --upgrade scipy==1.7.3
       - name: Use develop branch if specified
-        if: ${{ env.usedevelop }}
+        if: ${{ env.usedevelop == true }}
         run: |
           pip uninstall -y explorepy
           pip install git+https://github.com/Mentalab-hub/explorepy.git@develop

--- a/create-setup-file-windows-offline-working.bat
+++ b/create-setup-file-windows-offline-working.bat
@@ -27,6 +27,7 @@ call python -m pip install --upgrade pip
 
 @REM Install Pyinstaller
 call pip install pyinstaller==4.7
+call pip install --upgrade pyinstaller-hooks-contrib==2023.2
 
 @REM Install ExploreDesktop
 call pip install eeglabio
@@ -37,22 +38,24 @@ call pip uninstall scipy -y
 call pip install scipy==1.7.3
 
 @REM Uncomment below if ExploreDesktop required the develop branch of explorepy
-@REM call pip uninstall -y explorepy
-@REM call pip install git+https://github.com/Mentalab-hub/explorepy.git@develop
+call pip uninstall -y explorepy
+call pip install git+https://github.com/Mentalab-hub/explorepy.git@develop
 
 @REM  Clean required directories
 call set exploredesktop_path="installer\ExploreDesktopInstaller\ExploreDesktop\packages\com.Mentalab.ExploreDesktop\"
+call set exploredesktop_path_data="installer\ExploreDesktopInstaller\ExploreDesktop\packages\com.Mentalab.ExploreDesktop\data"
 call rd /S /Q %exploredesktop_path%data
 call md %exploredesktop_path%data
 call rd /S /Q dist
 
 @REM Create executable files
-call pyinstaller --onedir --console --noconfirm ExploreDesktop.spec
+@REM call pyinstaller --onedir --console --noconfirm ExploreDesktop.spec
+call pyinstaller --onedir --console --noconfirm --distpath %exploredesktop_path_data% ExploreDesktop.spec
 
 @REM Copy files to data dir
-call xcopy /I /E /H /R /Q dist\ExploreDesktop %exploredesktop_path%data\ExploreDesktop
-call xcopy %exploredesktop_path%extras\MentalabLogo.ico %exploredesktop_path%data
-call set /p asd="Files copied to data dir. Verify and hit enter to continue"
+@REM call xcopy /I /E /H /R /Q dist\ExploreDesktop %exploredesktop_path%data\ExploreDesktop
+call xcopy %exploredesktop_path%extras\MentalabLogo.ico %exploredesktop_path_data%
+@REM call set /p asd="Files copied to data dir. Verify and hit enter to continue"
 
 
 @REM Create installer file


### PR DESCRIPTION
A hook for pylsl has been added to the pyinstaller hooks which breaks the current installer generation.

This hotfix downgrades the version of the pyinstaller-hook-contrib library used (from 2023.3 to 2023.2) to make the installer generation work again (for now). It adds this change to the offline installer batch script (`create-setup-file-windows-offline-working.bat`) and the building workflow (`.github/workflows/building.yml`).

It also adds the workflow_dispatch event to the building workflow.