### PR TITLE
Made usedevelop a string

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -11,7 +11,7 @@ env:
   exploredesktop_path: 'installer\ExploreDesktopInstaller\ExploreDesktop\packages\com.Mentalab.ExploreDesktop\'
   config_path: 'installer\ExploreDesktopInstaller\ExploreDesktop\config\config.xml'
   package_path: 'installer\ExploreDesktopInstaller\ExploreDesktop\packages'
-  usedevelop: true
+  usedevelop: 'true'
 jobs:
   build:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
@@ -54,7 +54,7 @@ jobs:
           pip install -e .
           pip install --upgrade scipy==1.7.3
       - name: Use develop branch if specified
-        if: ${{ env.usedevelop == true }}
+        if: ${{ env.usedevelop == 'true' }}
         run: |
           pip uninstall -y explorepy
           pip install git+https://github.com/Mentalab-hub/explorepy.git@develop


### PR DESCRIPTION
I noticed that the workflow from Wednesday didn't run the step to checkout the develop branch of explorepy (I changed the condition to env.usedevelop == true which evaluated to false). Turns out the variable is interpreted as a string, so I made this clear in building.yml and changed the condition to env.usedevelop == 'true'. This variable could be used in the future to specify a specific branch to build with, for now the change ensures that explore-desktop builds with develop by default (and it's now clear how env.usedevelop is interpreted in the script).