### PR TITLE
base_data_module.py::_add_pos_line: return lines if pos NaN without c…

### DIFF
--- a/exploredesktop/modules/base_data_module.py
+++ b/exploredesktop/modules/base_data_module.py
@@ -1,5 +1,6 @@
 """Base module for data classes"""
 import logging
+import math
 from abc import abstractmethod
 from enum import Enum
 from typing import (
@@ -443,7 +444,8 @@ class BasePlots:
         """
         # the x coordinate is the last updated point of the time vector
         pos = t_vector[self.model.pointer - 1]
-
+        if math.isnan(pos):
+            return self.lines
         # at the beggining lines have to be initialized
         if None in self.lines:
             for idx, plt in enumerate(self.plots_list):


### PR DESCRIPTION
This fixes the freeze due to a read value in the time vector in `base_data_module.py::_add_pos_line` being unexpectedly NaN (specifically pos in `pos = t_vector[self.model.pointer - 1]`).
The error reported by pyqtgraph
`ang = round(item.transformAngle())
ValueError: cannot convert float NaN to integer`
is just a symptom of a NaN being passed as item (pos).

Anyway, this fix returns the list of lines prematurely if pos is NaN.